### PR TITLE
Fix “Installation” subsection of the description of `src` CLI extension

### DIFF
--- a/src/cli/src.md
+++ b/src/cli/src.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-RepoLink preprocessor is a part of MultiProject extension:
+To enable the `src` command, install MultiProject extension:
 
 <include nohead="true">
     $https://github.com/foliant-docs/foliantcontrib.multiproject.git$README.md#Installation:Config Extension to Resolve the `!from` Tag


### PR DESCRIPTION
Remove unnecessary mention of RepoLink preprocessor.