### PR TITLE
update repos.yml

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -13,7 +13,7 @@
 - https://github.com/foliant-docs/foliantcontrib.blockdiag.git
 - https://github.com/foliant-docs/foliantcontrib.bpmn.git
 - https://github.com/foliant-docs/foliantcontrib.bump.git
-# - https://github.com/foliant-docs/foliantcontrib.checksources.git
+- https://github.com/foliant-docs/foliantcontrib.checksources.git
 - https://github.com/foliant-docs/foliantcontrib.confluence.git
 - https://github.com/foliant-docs/foliantcontrib.csvtables.git
 - https://github.com/foliant-docs/foliantcontrib.customids.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 foliantcontrib.anchors
 foliantcontrib.flags >= 1.0.2
-foliantcontrib.history >= 1.0.8
+foliantcontrib.history >= 1.0.9
 foliantcontrib.includes >= 1.1.13
 foliantcontrib.macros >= 1.0.4
 foliantcontrib.mkdocs >= 1.0.13


### PR DESCRIPTION
`foliantcontrib.history` now uses the default branch, so the link `https://github.com/foliant-docs/foliantcontrib.checksources.git` can be commented out.